### PR TITLE
examples/argparse: Remove click example

### DIFF
--- a/docs/pages/examples/argparse.rst
+++ b/docs/pages/examples/argparse.rst
@@ -5,8 +5,3 @@ filename/filepath validator for argparse
 filename/filepath sanitizer for argparse
 --------------------------------------------------------
 .. include:: argparse_sanitizer.txt
-
-
-filename/filepath validator for click
---------------------------------------------------------
-.. include:: click_validator.txt


### PR DESCRIPTION
With the addition of `click.rst`, those examples are covered there instead.