### PR TITLE
Separate max_len functionality into max_filepath_len and max_filename_len

### DIFF
--- a/pathvalidate/_base.py
+++ b/pathvalidate/_base.py
@@ -5,8 +5,8 @@
 import abc
 import os
 import sys
-from typing import ClassVar, Optional, Sequence, Tuple
 import warnings
+from typing import ClassVar, Optional, Sequence, Tuple
 
 from ._common import normalize_platform, unprintable_ascii_chars
 from ._const import DEFAULT_MIN_LEN, Platform
@@ -80,7 +80,7 @@ class BaseFile:
         if max_filename_len is None or max_filename_len <= 0:
             self._max_filename_len = platform_max_filename_len
         else:
-            self._max_filename_len = min(max_filename_len, platform_max_filename_len)
+            self._max_filename_len = max_filename_len
         # name cannot be longer than max path length
         self._max_filename_len = min(self._max_filename_len, self._max_filepath_len)
 

--- a/pathvalidate/_filename.py
+++ b/pathvalidate/_filename.py
@@ -18,7 +18,6 @@ from .error import ErrorAttrKey, ErrorReason, InvalidCharError, ValidationError
 from .handler import ReservedNameHandler, ValidationErrorHandler
 
 
-_DEFAULT_MAX_FILENAME_LEN = 255
 _RE_INVALID_FILENAME = re.compile(f"[{re.escape(BaseFile._INVALID_FILENAME_CHARS):s}]", re.UNICODE)
 _RE_INVALID_WIN_FILENAME = re.compile(
     f"[{re.escape(BaseFile._INVALID_WIN_FILENAME_CHARS):s}]", re.UNICODE
@@ -28,7 +27,7 @@ _RE_INVALID_WIN_FILENAME = re.compile(
 class FileNameSanitizer(AbstractSanitizer):
     def __init__(
         self,
-        max_len: int = _DEFAULT_MAX_FILENAME_LEN,
+        max_len: Optional[int] = None,  # deprecated
         fs_encoding: Optional[str] = None,
         platform: Optional[PlatformType] = None,
         null_value_handler: Optional[ValidationErrorHandler] = None,
@@ -36,13 +35,21 @@ class FileNameSanitizer(AbstractSanitizer):
         additional_reserved_names: Optional[Sequence[str]] = None,
         validate_after_sanitize: bool = False,
         validator: Optional[AbstractValidator] = None,
+        max_filename_len: Optional[int] = None,
+        max_filepath_len: Optional[int] = None,
     ) -> None:
+        if max_len is not None:
+            warnings.warn(
+                "'max_len' is deprecated. Use 'max_filename_len' instead.",
+                DeprecationWarning,
+            )
+            max_filename_len = max_len
         if validator:
             fname_validator = validator
         else:
             fname_validator = FileNameValidator(
                 min_len=DEFAULT_MIN_LEN,
-                max_len=max_len,
+                max_len=max_filename_len,
                 fs_encoding=fs_encoding,
                 check_reserved=True,
                 additional_reserved_names=additional_reserved_names,
@@ -50,12 +57,12 @@ class FileNameSanitizer(AbstractSanitizer):
             )
 
         super().__init__(
-            max_len=max_len,
             fs_encoding=fs_encoding,
+            max_filename_len=max_filename_len,
+            max_filepath_len=max_filepath_len,
             null_value_handler=null_value_handler,
             reserved_name_handler=reserved_name_handler,
             additional_reserved_names=additional_reserved_names,
-            platform_max_len=_DEFAULT_MAX_FILENAME_LEN,
             platform=platform,
             validate_after_sanitize=validate_after_sanitize,
             validator=fname_validator,
@@ -75,7 +82,9 @@ class FileNameSanitizer(AbstractSanitizer):
             raise
 
         sanitized_filename = self._sanitize_regexp.sub(replacement_text, str(value))
-        sanitized_filename = truncate_str(sanitized_filename, self._fs_encoding, self.max_len)
+        sanitized_filename = truncate_str(
+            sanitized_filename, self._fs_encoding, self.max_filename_len
+        )
 
         try:
             self._validator.validate(sanitized_filename)
@@ -149,19 +158,27 @@ class FileNameValidator(BaseValidator):
     def __init__(
         self,
         min_len: int = DEFAULT_MIN_LEN,
-        max_len: int = _DEFAULT_MAX_FILENAME_LEN,
+        max_len: Optional[int] = None,  # deprecated
         fs_encoding: Optional[str] = None,
         platform: Optional[PlatformType] = None,
         check_reserved: bool = True,
         additional_reserved_names: Optional[Sequence[str]] = None,
+        max_filename_len: Optional[int] = None,
+        max_filepath_len: Optional[int] = None,
     ) -> None:
+        if max_len is not None:
+            warnings.warn(
+                "'max_len' is deprecated. Use 'max_filename_len' instead.",
+                DeprecationWarning,
+            )
+            max_filename_len = max_len
         super().__init__(
             min_len=min_len,
-            max_len=max_len,
+            max_filename_len=max_filename_len,
+            max_filepath_len=max_filepath_len,
             fs_encoding=fs_encoding,
             check_reserved=check_reserved,
             additional_reserved_names=additional_reserved_names,
-            platform_max_len=_DEFAULT_MAX_FILENAME_LEN,
             platform=platform,
         )
 
@@ -179,10 +196,10 @@ class FileNameValidator(BaseValidator):
             ErrorAttrKey.FS_ENCODING: self._fs_encoding,
             ErrorAttrKey.BYTE_COUNT: byte_ct,
         }
-        if byte_ct > self.max_len:
+        if byte_ct > self.max_filename_len:
             raise ValidationError(
                 [
-                    f"filename is too long: expected<={self.max_len:d} bytes, actual={byte_ct:d} bytes"
+                    f"filename is too long: expected<={self.max_filename_len:d} bytes, actual={byte_ct:d} bytes"
                 ],
                 **err_kwargs,
             )
@@ -266,10 +283,12 @@ def validate_filename(
     filename: PathType,
     platform: Optional[PlatformType] = None,
     min_len: int = DEFAULT_MIN_LEN,
-    max_len: int = _DEFAULT_MAX_FILENAME_LEN,
+    max_len: Optional[int] = None,  # deprecated
     fs_encoding: Optional[str] = None,
     check_reserved: bool = True,
     additional_reserved_names: Optional[Sequence[str]] = None,
+    max_filename_len: Optional[int] = None,
+    max_filepath_len: Optional[int] = None,
 ) -> None:
     """Verifying whether the ``filename`` is a valid file name or not.
 
@@ -284,14 +303,7 @@ def validate_filename(
             Minimum byte length of the ``filename``. The value must be greater or equal to one.
             Defaults to ``1``.
         max_len:
-            Maximum byte length of the ``filename``. The value must be lower than:
-
-                - ``Linux``: 4096
-                - ``macOS``: 1024
-                - ``Windows``: 260
-                - ``universal``: 260
-
-            Defaults to ``255``.
+            [Deprecated] Use 'max_filename_len' instead.
         fs_encoding:
             Filesystem encoding that used to calculate the byte length of the filename.
             If |None|, get the value from the execution environment.
@@ -300,10 +312,21 @@ def validate_filename(
         additional_reserved_names:
             Additional reserved names to check.
             Case insensitive.
+        max_filename_len:
+            Maximum byte length of the ``filename``.
+            Defaults to ``255``.
+        max_filepath_len:
+            Maximum byte length of the file path.
+            Defaults to:
+
+                - ``Linux``: 4096
+                - ``macOS``: 1024
+                - ``Windows``: 260
+                - ``universal``: 260
 
     Raises:
         ValidationError (ErrorReason.INVALID_LENGTH):
-            If the ``filename`` is longer than ``max_len`` characters.
+            If the ``filename`` is longer than ``max_filename_len`` characters.
         ValidationError (ErrorReason.INVALID_CHARACTER):
             If the ``filename`` includes invalid character(s) for a filename:
             |invalid_filename_chars|.
@@ -321,11 +344,17 @@ def validate_filename(
         `Naming Files, Paths, and Namespaces - Win32 apps | Microsoft Docs
         <https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file>`__
     """
-
+    if max_len is not None:
+        warnings.warn(
+            "'max_len' is deprecated. Use 'max_filename_len' instead.",
+            DeprecationWarning,
+        )
+        max_filename_len = max_len
     FileNameValidator(
         platform=platform,
         min_len=min_len,
-        max_len=max_len,
+        max_filename_len=max_filename_len,
+        max_filepath_len=max_filepath_len,
         fs_encoding=fs_encoding,
         check_reserved=check_reserved,
         additional_reserved_names=additional_reserved_names,
@@ -336,10 +365,12 @@ def is_valid_filename(
     filename: PathType,
     platform: Optional[PlatformType] = None,
     min_len: int = DEFAULT_MIN_LEN,
-    max_len: Optional[int] = None,
+    max_len: Optional[int] = None,  # deprecated
     fs_encoding: Optional[str] = None,
     check_reserved: bool = True,
     additional_reserved_names: Optional[Sequence[str]] = None,
+    max_filename_len: Optional[int] = None,
+    max_filepath_len: Optional[int] = None,
 ) -> bool:
     """Check whether the ``filename`` is a valid name or not.
 
@@ -355,11 +386,18 @@ def is_valid_filename(
     See Also:
         :py:func:`.validate_filename()`
     """
+    if max_len is not None:
+        warnings.warn(
+            "'max_len' is deprecated. Use 'max_filename_len' instead.",
+            DeprecationWarning,
+        )
+        max_filename_len = max_len
 
     return FileNameValidator(
         platform=platform,
         min_len=min_len,
-        max_len=-1 if max_len is None else max_len,
+        max_filename_len=max_filename_len,
+        max_filepath_len=max_filepath_len,
         fs_encoding=fs_encoding,
         check_reserved=check_reserved,
         additional_reserved_names=additional_reserved_names,
@@ -370,13 +408,15 @@ def sanitize_filename(
     filename: PathType,
     replacement_text: str = "",
     platform: Optional[PlatformType] = None,
-    max_len: Optional[int] = _DEFAULT_MAX_FILENAME_LEN,
+    max_len: Optional[int] = None,  # deprecated
     fs_encoding: Optional[str] = None,
     check_reserved: Optional[bool] = None,
     null_value_handler: Optional[ValidationErrorHandler] = None,
     reserved_name_handler: Optional[ValidationErrorHandler] = None,
     additional_reserved_names: Optional[Sequence[str]] = None,
     validate_after_sanitize: bool = False,
+    max_filename_len: Optional[int] = None,
+    max_filepath_len: Optional[int] = None,
 ) -> PathType:
     """Make a valid filename from a string.
 
@@ -401,9 +441,7 @@ def sanitize_filename(
 
             .. include:: platform.txt
         max_len:
-            Maximum byte length of the ``filename``.
-            Truncate the name length if the ``filename`` length exceeds this value.
-            Defaults to ``255``.
+            [Deprecated] Use 'max_filename_len' instead.
         fs_encoding:
             Filesystem encoding that used to calculate the byte length of the filename.
             If |None|, get the value from the execution environment.
@@ -433,6 +471,18 @@ def sanitize_filename(
             Case insensitive.
         validate_after_sanitize:
             Execute validation after sanitization to the file name.
+        max_filename_len:
+            Maximum byte length of the ``filename``.
+            Truncate the name length if the ``filename`` length exceeds this value.
+            Defaults to ``255``.
+        max_filepath_len:
+            Maximum byte length of the file path.
+            Defaults to:
+
+                - ``Linux``: 4096
+                - ``macOS``: 1024
+                - ``Windows``: 260
+                - ``universal``: 260
 
     Returns:
         Same type as the ``filename`` (str or PathLike object):
@@ -445,6 +495,12 @@ def sanitize_filename(
     Example:
         :ref:`example-sanitize-filename`
     """
+    if max_len is not None:
+        warnings.warn(
+            "'max_len' is deprecated. Use 'max_filename_len' instead.",
+            DeprecationWarning,
+        )
+        max_filename_len = max_len
 
     if check_reserved is not None:
         warnings.warn(
@@ -457,7 +513,8 @@ def sanitize_filename(
 
     return FileNameSanitizer(
         platform=platform,
-        max_len=-1 if max_len is None else max_len,
+        max_filename_len=max_filename_len,
+        max_filepath_len=max_filepath_len,
         fs_encoding=fs_encoding,
         null_value_handler=null_value_handler,
         reserved_name_handler=reserved_name_handler,

--- a/pathvalidate/_filepath.py
+++ b/pathvalidate/_filepath.py
@@ -26,7 +26,7 @@ _RE_INVALID_WIN_PATH = re.compile(f"[{re.escape(BaseFile._INVALID_WIN_PATH_CHARS
 class FilePathSanitizer(AbstractSanitizer):
     def __init__(
         self,
-        max_len: int = -1,
+        max_len: Optional[int] = None,  # deprecated
         fs_encoding: Optional[str] = None,
         platform: Optional[PlatformType] = None,
         null_value_handler: Optional[ValidationErrorHandler] = None,
@@ -35,20 +35,31 @@ class FilePathSanitizer(AbstractSanitizer):
         normalize: bool = True,
         validate_after_sanitize: bool = False,
         validator: Optional[AbstractValidator] = None,
+        max_filename_len: Optional[int] = None,
+        max_filepath_len: Optional[int] = None,
     ) -> None:
+        if max_len is not None:
+            warnings.warn(
+                "'max_len' is deprecated. Use 'max_filepath_len' instead.",
+                DeprecationWarning,
+            )
+            max_filepath_len = max_len
+
         if validator:
             fpath_validator = validator
         else:
             fpath_validator = FilePathValidator(
                 min_len=DEFAULT_MIN_LEN,
-                max_len=max_len,
+                max_filename_len=max_filename_len,
+                max_filepath_len=max_filepath_len,
                 fs_encoding=fs_encoding,
                 check_reserved=True,
                 additional_reserved_names=additional_reserved_names,
                 platform=platform,
             )
         super().__init__(
-            max_len=max_len,
+            max_filename_len=max_filename_len,
+            max_filepath_len=max_filepath_len,
             fs_encoding=fs_encoding,
             validator=fpath_validator,
             null_value_handler=null_value_handler,
@@ -60,7 +71,8 @@ class FilePathSanitizer(AbstractSanitizer):
 
         self._sanitize_regexp = self._get_sanitize_regexp()
         self.__fname_sanitizer = FileNameSanitizer(
-            max_len=self.max_len,
+            max_filename_len=self.max_filename_len,
+            max_filepath_len=self.max_filepath_len,
             fs_encoding=fs_encoding,
             null_value_handler=null_value_handler,
             reserved_name_handler=reserved_name_handler,
@@ -161,15 +173,24 @@ class FilePathValidator(BaseValidator):
     def __init__(
         self,
         min_len: int = DEFAULT_MIN_LEN,
-        max_len: int = -1,
+        max_len: Optional[int] = None,  # deprecated
         fs_encoding: Optional[str] = None,
         platform: Optional[PlatformType] = None,
         check_reserved: bool = True,
         additional_reserved_names: Optional[Sequence[str]] = None,
+        max_filename_len: Optional[int] = None,
+        max_filepath_len: Optional[int] = None,
     ) -> None:
+        if max_len is not None:
+            warnings.warn(
+                "'max_len' is deprecated. Use 'max_filepath_len' instead.",
+                DeprecationWarning,
+            )
+            max_filepath_len = max_len
         super().__init__(
             min_len=min_len,
-            max_len=max_len,
+            max_filename_len=max_filename_len,
+            max_filepath_len=max_filepath_len,
             fs_encoding=fs_encoding,
             check_reserved=check_reserved,
             additional_reserved_names=additional_reserved_names,
@@ -206,10 +227,10 @@ class FilePathValidator(BaseValidator):
             ErrorAttrKey.BYTE_COUNT: byte_ct,
         }
 
-        if byte_ct > self.max_len:
+        if byte_ct > self.max_filepath_len:
             raise ValidationError(
                 [
-                    f"file path is too long: expected<={self.max_len:d} bytes, actual={byte_ct:d} bytes"
+                    f"file path is too long: expected<={self.max_filepath_len:d} bytes, actual={byte_ct:d} bytes"
                 ],
                 **err_kwargs,
             )
@@ -307,10 +328,12 @@ def validate_filepath(
     file_path: PathType,
     platform: Optional[PlatformType] = None,
     min_len: int = DEFAULT_MIN_LEN,
-    max_len: Optional[int] = None,
+    max_len: Optional[int] = None,  # deprecated
     fs_encoding: Optional[str] = None,
     check_reserved: bool = True,
     additional_reserved_names: Optional[Sequence[str]] = None,
+    max_filename_len: Optional[int] = None,
+    max_filepath_len: Optional[int] = None,
 ) -> None:
     """Verifying whether the ``file_path`` is a valid file path or not.
 
@@ -325,13 +348,7 @@ def validate_filepath(
             Minimum byte length of the ``file_path``. The value must be greater or equal to one.
             Defaults to ``1``.
         max_len (Optional[int], optional):
-            Maximum byte length of the ``file_path``. If the value is |None| or minus,
-            automatically determined by the ``platform``:
-
-                - ``Linux``: 4096
-                - ``macOS``: 1024
-                - ``Windows``: 260
-                - ``universal``: 260
+            [Deprecated] Use 'max_filepath_len' instead.
         fs_encoding (Optional[str], optional):
             Filesystem encoding that used to calculate the byte length of the file path.
             If |None|, get the value from the execution environment.
@@ -340,6 +357,17 @@ def validate_filepath(
             Defaults to |True|.
         additional_reserved_names (Optional[Sequence[str]], optional):
             Additional reserved names to check.
+        max_filename_len:
+            Maximum byte length of each component of the ``file_path``.
+            Defaults to ``255``.
+        max_filepath_len:
+            Maximum byte length of the ``file_path``.
+            Defaults to:
+
+                - ``Linux``: 4096
+                - ``macOS``: 1024
+                - ``Windows``: 260
+                - ``universal``: 260
 
     Raises:
         ValidationError (ErrorReason.INVALID_CHARACTER):
@@ -359,11 +387,18 @@ def validate_filepath(
         `Naming Files, Paths, and Namespaces - Win32 apps | Microsoft Docs
         <https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file>`__
     """
+    if max_len is not None:
+        warnings.warn(
+            "'max_len' is deprecated. Use 'max_filepath_len' instead.",
+            DeprecationWarning,
+        )
+        max_filepath_len = max_len
 
     FilePathValidator(
         platform=platform,
         min_len=min_len,
-        max_len=-1 if max_len is None else max_len,
+        max_filename_len=max_filename_len,
+        max_filepath_len=max_filepath_len,
         fs_encoding=fs_encoding,
         check_reserved=check_reserved,
         additional_reserved_names=additional_reserved_names,
@@ -374,10 +409,12 @@ def is_valid_filepath(
     file_path: PathType,
     platform: Optional[PlatformType] = None,
     min_len: int = DEFAULT_MIN_LEN,
-    max_len: Optional[int] = None,
+    max_len: Optional[int] = None,  # deprecated
     fs_encoding: Optional[str] = None,
     check_reserved: bool = True,
     additional_reserved_names: Optional[Sequence[str]] = None,
+    max_filename_len: Optional[int] = None,
+    max_filepath_len: Optional[int] = None,
 ) -> bool:
     """Check whether the ``file_path`` is a valid name or not.
 
@@ -393,11 +430,18 @@ def is_valid_filepath(
     See Also:
         :py:func:`.validate_filepath()`
     """
+    if max_len is not None:
+        warnings.warn(
+            "'max_len' is deprecated. Use 'max_filepath_len' instead.",
+            DeprecationWarning,
+        )
+        max_filepath_len = max_len
 
     return FilePathValidator(
         platform=platform,
         min_len=min_len,
-        max_len=-1 if max_len is None else max_len,
+        max_filename_len=max_filename_len,
+        max_filepath_len=max_filepath_len,
         fs_encoding=fs_encoding,
         check_reserved=check_reserved,
         additional_reserved_names=additional_reserved_names,
@@ -408,7 +452,7 @@ def sanitize_filepath(
     file_path: PathType,
     replacement_text: str = "",
     platform: Optional[PlatformType] = None,
-    max_len: Optional[int] = None,
+    max_len: Optional[int] = None,  # deprecated
     fs_encoding: Optional[str] = None,
     check_reserved: Optional[bool] = None,
     null_value_handler: Optional[ValidationErrorHandler] = None,
@@ -416,6 +460,8 @@ def sanitize_filepath(
     additional_reserved_names: Optional[Sequence[str]] = None,
     normalize: bool = True,
     validate_after_sanitize: bool = False,
+    max_filename_len: Optional[int] = None,
+    max_filepath_len: Optional[int] = None,
 ) -> PathType:
     """Make a valid file path from a string.
 
@@ -442,14 +488,7 @@ def sanitize_filepath(
 
             .. include:: platform.txt
         max_len:
-            Maximum byte length of the file path.
-            Truncate the path if the value length exceeds the `max_len`.
-            If the value is |None| or minus, ``max_len`` will automatically determined by the ``platform``:
-
-                - ``Linux``: 4096
-                - ``macOS``: 1024
-                - ``Windows``: 260
-                - ``universal``: 260
+            [Deprecated] Use 'max_filepath_len' instead.
         fs_encoding:
             Filesystem encoding that used to calculate the byte length of the file path.
             If |None|, get the value from the execution environment.
@@ -481,6 +520,18 @@ def sanitize_filepath(
             If |True|, normalize the the file path.
         validate_after_sanitize:
             Execute validation after sanitization to the file path.
+        max_filename_len:
+            Maximum byte length of each component of the ``file_path``.
+            Truncate each component if the length exceeds this value.
+            Defaults to ``255``.
+        max_filepath_len:
+            Maximum byte length of the ``file_path``.
+            Defaults to:
+
+                - ``Linux``: 4096
+                - ``macOS``: 1024
+                - ``Windows``: 260
+                - ``universal``: 260
 
     Returns:
         Same type as the argument (str or PathLike object):
@@ -493,6 +544,12 @@ def sanitize_filepath(
     Example:
         :ref:`example-sanitize-file-path`
     """
+    if max_len is not None:
+        warnings.warn(
+            "'max_len' is deprecated. Use 'max_filepath_len' instead.",
+            DeprecationWarning,
+        )
+        max_filepath_len = max_len
 
     if check_reserved is not None:
         warnings.warn(
@@ -505,7 +562,8 @@ def sanitize_filepath(
 
     return FilePathSanitizer(
         platform=platform,
-        max_len=-1 if max_len is None else max_len,
+        max_filename_len=max_filename_len,
+        max_filepath_len=max_filepath_len,
         fs_encoding=fs_encoding,
         normalize=normalize,
         null_value_handler=null_value_handler,

--- a/pathvalidate/_filepath.py
+++ b/pathvalidate/_filepath.py
@@ -199,7 +199,9 @@ class FilePathValidator(BaseValidator):
 
         self.__fname_validator = FileNameValidator(
             min_len=min_len,
-            max_len=max_len,
+            max_filename_len=self.max_filename_len,
+            max_filepath_len=self.max_filepath_len,
+            fs_encoding=fs_encoding,
             check_reserved=check_reserved,
             additional_reserved_names=additional_reserved_names,
             platform=platform,
@@ -249,8 +251,7 @@ class FilePathValidator(BaseValidator):
         for entry in unicode_filepath.split("/"):
             if not entry or entry in (".", ".."):
                 continue
-
-            self.__fname_validator._validate_reserved_keywords(entry)
+            self.__fname_validator.validate(entry)
 
         if self._is_windows(include_universal=True):
             self.__validate_win_filepath(unicode_filepath)

--- a/test/test_filepath.py
+++ b/test/test_filepath.py
@@ -4,6 +4,7 @@
 .. codeauthor:: Tsuyoshi Hombashi <tsuyoshi.hombashi@gmail.com>
 """
 
+import math
 import platform as m_platform
 import random
 import sys
@@ -216,7 +217,8 @@ class Test_validate_filepath:
     def test_normal_max_len(self, value, platform, max_len, expected):
         kwargs = {
             "platform": platform,
-            "max_len": max_len,
+            "max_filepath_len": max_len,
+            "max_filename_len": math.inf,  # ignore filename checks
         }
 
         if expected is None:
@@ -376,8 +378,13 @@ class Test_validate_filepath:
         ],
     )
     def test_normal_space_or_period_at_tail(self, platform, value):
-        validate_filepath(value, platform=platform)
-        assert is_valid_filepath(value, platform=platform)
+        if platform == "windows" or platform == "universal":
+            with pytest.raises(ValidationError):
+                validate_filepath(value, platform=platform)
+            assert not is_valid_filepath(value, platform=platform)
+        else:
+            validate_filepath(value, platform=platform)
+            assert is_valid_filepath(value, platform=platform)
 
     @pytest.mark.skipif(not is_faker_installed(), reason="requires faker")
     @pytest.mark.parametrize(


### PR DESCRIPTION
Fix for #51. Is mostly backwards compatible, with some slight behavior changes (fixes):

e.g. `validate_filepath("a" * 256, platform="Linux")` used to not raise an error. Now it will raise an INVALID_LENGTH error, which is consistent with `validate_filename("a" * 256, platform="Linux")`.

I also fixed the `test_normal_space_or_period_at_tail` test for the Windows and universal platforms.