### PR TITLE
Adapt tests for Python >= 3.13

### DIFF
--- a/test/test_filename.py
+++ b/test/test_filename.py
@@ -418,7 +418,10 @@ class Test_validate_filename:
         else:
             with pytest.raises(expected) as e:
                 validate_filename(value, platform=platform)
-            assert e.value.reason == ErrorReason.FOUND_ABS_PATH
+            assert e.value.reason in [
+                ErrorReason.FOUND_ABS_PATH,
+                ErrorReason.INVALID_CHARACTER,
+                ]
 
     @pytest.mark.parametrize(
         ["value", "platform"],

--- a/test/test_filepath.py
+++ b/test/test_filepath.py
@@ -289,7 +289,7 @@ class Test_validate_filepath:
         [
             ["linux", "/a/b/c.txt", None],
             ["linux", "C:\\a\\b\\c.txt", ValidationError],
-            ["windows", "/a/b/c.txt", None],
+            ["windows", "/a/b/c.txt", None if sys.version_info < (3, 13) else ValidationError],
             ["windows", "C:\\a\\b\\c.txt", None],
             ["universal", "/a/b/c.txt", ValidationError],
             ["universal", "C:\\a\\b\\c.txt", ValidationError],


### PR DESCRIPTION
The evaluation of absolute paths on Windows has been changed in
Python 3.13: https://docs.python.org/3.13/whatsnew/3.13.html#os-path

Fix #39.
