### PR TITLE
Fix validation functions of filepaths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           path: ./dist
 
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v2.1.1
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/examples/pathvalidate_examples.ipynb
+++ b/examples/pathvalidate_examples.ipynb
@@ -30,14 +30,14 @@
     "from pathvalidate import ValidationError, validate_filename\n",
     "\n",
     "try:\n",
-    "    validate_filename(\"fi:l*e/p\\\"a?t>h|.t<xt\")\n",
+    "    validate_filename('fi:l*e/p\"a?t>h|.t<xt')\n",
     "except ValidationError as e:\n",
     "    print(f\"{e}\\n\", file=sys.stderr)\n",
     "\n",
     "try:\n",
     "    validate_filename(\"COM1\")\n",
     "except ValidationError as e:\n",
-    "    print(f\"{e}\\n\", file=sys.stderr)\n"
+    "    print(f\"{e}\\n\", file=sys.stderr)"
    ]
   },
   {
@@ -81,7 +81,7 @@
     "from pathvalidate import ValidationError, validate_filepath\n",
     "\n",
     "try:\n",
-    "    validate_filepath(\"fi:l*e/p\\\"a?t>h|.t<xt\")\n",
+    "    validate_filepath('fi:l*e/p\"a?t>h|.t<xt')\n",
     "except ValidationError as e:\n",
     "    print(e, file=sys.stderr)"
    ]
@@ -105,7 +105,7 @@
    "source": [
     "from pathvalidate import sanitize_filename\n",
     "\n",
-    "fname = \"fi:l*e/p\\\"a?t>h|.t<xt\"\n",
+    "fname = 'fi:l*e/p\"a?t>h|.t<xt'\n",
     "print(f\"{fname} -> {sanitize_filename(fname)}\\n\")\n",
     "\n",
     "fname = \"\\0_a*b:c<d>e%f/(g)h+i_0.txt\"\n",
@@ -131,7 +131,7 @@
    "source": [
     "from pathvalidate import sanitize_filepath\n",
     "\n",
-    "fpath = \"fi:l*e/p\\\"a?t>h|.t<xt\"\n",
+    "fpath = 'fi:l*e/p\"a?t>h|.t<xt'\n",
     "print(f\"{fpath} -> {sanitize_filepath(fpath)}\\n\")\n",
     "\n",
     "fpath = \"\\0_a*b:c<d>e%f/(g)h+i_0.txt\"\n",
@@ -177,7 +177,7 @@
    "source": [
     "from pathvalidate import is_valid_filename, sanitize_filename\n",
     "\n",
-    "fname = \"fi:l*e/p\\\"a?t>h|.t<xt\"\n",
+    "fname = 'fi:l*e/p\"a?t>h|.t<xt'\n",
     "print(f\"is_valid_filename('{fname}') return {is_valid_filename(fname)}\\n\")\n",
     "\n",
     "sanitized_fname = sanitize_filename(fname)\n",
@@ -203,7 +203,7 @@
    "source": [
     "from pathvalidate import is_valid_filepath, sanitize_filepath\n",
     "\n",
-    "fpath = \"fi:l*e/p\\\"a?t>h|.t<xt\"\n",
+    "fpath = 'fi:l*e/p\"a?t>h|.t<xt'\n",
     "print(f\"is_valid_filepath('{fpath}') return {is_valid_filepath(fpath)}\\n\")\n",
     "\n",
     "sanitized_fpath = sanitize_filepath(fpath)\n",
@@ -229,13 +229,17 @@
    "source": [
     "from pathvalidate import sanitize_filename, ValidationError\n",
     "\n",
+    "\n",
     "def add_trailing_underscore(e: ValidationError) -> str:\n",
     "    if e.reusable_name:\n",
     "        return e.reserved_name\n",
     "\n",
     "    return f\"{e.reserved_name}_\"\n",
     "\n",
-    "sanitize_filename(\".\", reserved_name_handler=add_trailing_underscore, additional_reserved_names=[\".\"])\n"
+    "\n",
+    "sanitize_filename(\n",
+    "    \".\", reserved_name_handler=add_trailing_underscore, additional_reserved_names=[\".\"]\n",
+    ")"
    ]
   }
  ],

--- a/pathvalidate/_common.py
+++ b/pathvalidate/_common.py
@@ -2,9 +2,11 @@
 .. codeauthor:: Tsuyoshi Hombashi <tsuyoshi.hombashi@gmail.com>
 """
 
+import ntpath
 import platform
 import re
 import string
+import sys
 from pathlib import PurePath
 from typing import Any, List, Optional
 
@@ -37,6 +39,19 @@ def to_str(name: PathType) -> str:
         return str(name)
 
     return name
+
+
+def is_nt_abspath(value: str) -> bool:
+    ver_info = sys.version_info[:2]
+    if ver_info <= (3, 10):
+        if value.startswith("\\\\"):
+            return True
+    elif ver_info >= (3, 13):
+        return ntpath.isabs(value)
+
+    drive, _tail = ntpath.splitdrive(value)
+
+    return ntpath.isabs(value) and len(drive) > 0
 
 
 def is_null_string(value: Any) -> bool:

--- a/pathvalidate/_filename.py
+++ b/pathvalidate/_filename.py
@@ -3,7 +3,6 @@
 """
 
 import itertools
-import ntpath
 import posixpath
 import re
 import warnings
@@ -11,7 +10,7 @@ from pathlib import Path, PurePath
 from typing import Optional, Pattern, Sequence, Tuple
 
 from ._base import AbstractSanitizer, AbstractValidator, BaseFile, BaseValidator
-from ._common import findall_to_str, to_str, truncate_str, validate_pathtype
+from ._common import findall_to_str, is_nt_abspath, to_str, truncate_str, validate_pathtype
 from ._const import DEFAULT_MIN_LEN, INVALID_CHAR_ERR_MSG_TMPL, Platform
 from ._types import PathType, PlatformType
 from .error import ErrorAttrKey, ErrorReason, InvalidCharError, ValidationError
@@ -55,7 +54,6 @@ class FileNameSanitizer(AbstractSanitizer):
             null_value_handler=null_value_handler,
             reserved_name_handler=reserved_name_handler,
             additional_reserved_names=additional_reserved_names,
-            platform_max_len=_DEFAULT_MAX_FILENAME_LEN,
             platform=platform,
             validate_after_sanitize=validate_after_sanitize,
             validator=fname_validator,
@@ -161,7 +159,6 @@ class FileNameValidator(BaseValidator):
             fs_encoding=fs_encoding,
             check_reserved=check_reserved,
             additional_reserved_names=additional_reserved_names,
-            platform_max_len=_DEFAULT_MAX_FILENAME_LEN,
             platform=platform,
         )
 
@@ -208,7 +205,7 @@ class FileNameValidator(BaseValidator):
         )
 
         if self._is_windows(include_universal=True):
-            if ntpath.isabs(value):
+            if is_nt_abspath(value):
                 raise err
 
         if posixpath.isabs(value):

--- a/test/test_filepath.py
+++ b/test/test_filepath.py
@@ -289,7 +289,7 @@ class Test_validate_filepath:
         [
             ["linux", "/a/b/c.txt", None],
             ["linux", "C:\\a\\b\\c.txt", ValidationError],
-            ["windows", "/a/b/c.txt", None],
+            ["windows", "/a/b/c.txt", ValidationError],
             ["windows", "C:\\a\\b\\c.txt", None],
             ["universal", "/a/b/c.txt", ValidationError],
             ["universal", "C:\\a\\b\\c.txt", ValidationError],
@@ -363,21 +363,31 @@ class Test_validate_filepath:
     @pytest.mark.parametrize(
         ["platform", "value"],
         [
-            ["windows", "period."],
-            ["windows", "space "],
-            ["windows", "space_and_period ."],
-            ["windows", "space_and_period. "],
             ["linux", "period."],
             ["linux", "space "],
             ["linux", "space_and_period. "],
-            ["universal", "period."],
-            ["universal", "space "],
-            ["universal", "space_and_period ."],
         ],
     )
     def test_normal_space_or_period_at_tail(self, platform, value):
         validate_filepath(value, platform=platform)
         assert is_valid_filepath(value, platform=platform)
+
+    @pytest.mark.parametrize(
+        ["platform", "value"],
+        [
+            ["windows", "period."],
+            ["windows", "space "],
+            ["windows", "space_and_period ."],
+            ["windows", "space_and_period. "],
+            ["universal", "period."],
+            ["universal", "space "],
+            ["universal", "space_and_period ."],
+        ],
+    )
+    def test_exception_space_or_period_at_tail(self, platform, value):
+        with pytest.raises(ValidationError):
+            validate_filepath(value, platform=platform)
+        assert not is_valid_filepath(value, platform=platform)
 
     @pytest.mark.skipif(not is_faker_installed(), reason="requires faker")
     @pytest.mark.parametrize(


### PR DESCRIPTION
- If `platform` argument is `windows` or `universal`, filepaths ending with a space or a period are should be detected as an error
- Fix POSIX-style absolute paths were not detected as errors with `platform="windows"` 

Related to #39